### PR TITLE
add sorted list and only use of pointer when its needed

### DIFF
--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -3,6 +3,7 @@ package envoy
 import (
 	"fmt"
 	"log"
+	"sort"
 
 	cal "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	v3cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -61,6 +62,10 @@ func init() {
 
 func makeVirtualHost(vhost *virtualHost, reselectionAttempts int64) *route.VirtualHost {
 	routes := []*route.Route{}
+	// sort vhosts routes to make sure the bigger matching url is first
+	sort.Slice(vhost.Routes, func(i, j int) bool {
+		return len(vhost.Routes[i].Route.String()) > len(vhost.Routes[j].Route.String())
+	})
 	for _, matched := range vhost.Routes {
 		action := &route.Route_Route{
 			Route: &route.RouteAction{
@@ -85,7 +90,7 @@ func makeVirtualHost(vhost *virtualHost, reselectionAttempts int64) *route.Virtu
 		}
 
 		make := route.Route{
-			Match:  matched.Route,
+			Match:  &matched.Route,
 			Action: action,
 		}
 		routes = append(routes, &make)

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -71,7 +71,7 @@ type virtualHost struct {
 
 type Localroute struct {
 	UpstreamCluster string
-	Route           *envoy_route_v3.RouteMatch
+	Route           envoy_route_v3.RouteMatch
 }
 
 type key struct {
@@ -216,7 +216,7 @@ func (ing *virtualHost) addVhostTimeout(timeout time.Duration) {
 	ing.PerTryTimeout = timeout
 }
 
-func (ing *virtualHost) addlocalroute(clusternmae string, route *envoy_route_v3.RouteMatch) {
+func (ing *virtualHost) addlocalroute(clusternmae string, route envoy_route_v3.RouteMatch) {
 	make := Localroute{Route: route, UpstreamCluster: clusternmae}
 	ing.Routes = append(ing.Routes, &make)
 }

--- a/pkg/envoy/route.go
+++ b/pkg/envoy/route.go
@@ -116,10 +116,10 @@ func Pathtranslate(path string, pathtype v1.PathType) *Route {
 }
 
 // RouteMatch creates a *envoy_route_v3.RouteMatch for the supplied *dag.Route.
-func RouteMatch(route *Route) *envoy_route_v3.RouteMatch {
+func RouteMatch(route *Route) envoy_route_v3.RouteMatch {
 	switch c := route.PathMatchCondition.(type) {
 	case *RegexMatchCondition:
-		return &envoy_route_v3.RouteMatch{
+		return envoy_route_v3.RouteMatch{
 			PathSpecifier: &envoy_route_v3.RouteMatch_SafeRegex{
 				// Add an anchor since we at the very least have a / as a string literal prefix.
 				// Reduces regex program size so Envoy doesn't reject long prefix matches.
@@ -129,7 +129,7 @@ func RouteMatch(route *Route) *envoy_route_v3.RouteMatch {
 	case *PrefixMatchCondition:
 		switch c.PrefixMatchType {
 		case PrefixMatchSegment:
-			return &envoy_route_v3.RouteMatch{
+			return envoy_route_v3.RouteMatch{
 				PathSpecifier: &envoy_route_v3.RouteMatch_PathSeparatedPrefix{
 					PathSeparatedPrefix: c.Prefix,
 				},
@@ -137,20 +137,20 @@ func RouteMatch(route *Route) *envoy_route_v3.RouteMatch {
 		case PrefixMatchString:
 			fallthrough
 		default:
-			return &envoy_route_v3.RouteMatch{
+			return envoy_route_v3.RouteMatch{
 				PathSpecifier: &envoy_route_v3.RouteMatch_Prefix{
 					Prefix: c.Prefix,
 				},
 			}
 		}
 	case *ExactMatchCondition:
-		return &envoy_route_v3.RouteMatch{
+		return envoy_route_v3.RouteMatch{
 			PathSpecifier: &envoy_route_v3.RouteMatch_Path{
 				Path: c.Path,
 			},
 		}
 	default:
-		return &envoy_route_v3.RouteMatch{}
+		return envoy_route_v3.RouteMatch{}
 	}
 }
 


### PR DESCRIPTION
In boilerplate added a sort function to sort route base on length of routes 
because the envoy connection manager [match the routes base on order  ](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/route_matching)

and use less of pointers to avoid unintentional change of value and use of & (copy of pointer) whenever its needed 