### PR TITLE
use entire ingress controller endpoints as cluster endpoint

### DIFF
--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -3,6 +3,7 @@ package envoy
 import (
 	"fmt"
 	"log"
+	"sort"
 
 	cal "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	v3cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -61,6 +62,10 @@ func init() {
 
 func makeVirtualHost(vhost *virtualHost, reselectionAttempts int64) *route.VirtualHost {
 	routes := []*route.Route{}
+	// sort vhosts routes to make sure the bigger matching url is first
+	sort.Slice(vhost.Routes, func(i, j int) bool {
+		return len(vhost.Routes[i].Route.String()) > len(vhost.Routes[j].Route.String())
+	})
 	for _, matched := range vhost.Routes {
 		action := &route.Route_Route{
 			Route: &route.RouteAction{
@@ -85,7 +90,7 @@ func makeVirtualHost(vhost *virtualHost, reselectionAttempts int64) *route.Virtu
 		}
 
 		make := route.Route{
-			Match:  matched.Route,
+			Match:  &matched.Route,
 			Action: action,
 		}
 		routes = append(routes, &make)

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -71,7 +71,7 @@ type virtualHost struct {
 
 type Localroute struct {
 	UpstreamCluster string
-	Route           *envoy_route_v3.RouteMatch
+	Route           envoy_route_v3.RouteMatch
 }
 
 type key struct {
@@ -213,7 +213,7 @@ func (ing *virtualHost) addVhostTimeout(timeout time.Duration) {
 	ing.PerTryTimeout = timeout
 }
 
-func (ing *virtualHost) addlocalroute(clusternmae string, route *envoy_route_v3.RouteMatch) {
+func (ing *virtualHost) addlocalroute(clusternmae string, route envoy_route_v3.RouteMatch) {
 	make := Localroute{Route: route, UpstreamCluster: clusternmae}
 	ing.Routes = append(ing.Routes, &make)
 }

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -168,7 +168,7 @@ func validIngressFilter(ingresses []v1.Ingress) []v1.Ingress {
 
 Ingress:
 	for _, i := range ingresses {
-		if i.Status.LoadBalancer.Ingress != nil || i.Annotations["ingressendpoints"] != "" {
+		if i.Status.LoadBalancer.Ingress != nil || i.Annotations["yggdrasil.uswitch.com/ingressendpoints"] != "" {
 			for _, k := range i.Spec.Rules {
 				if k.Host != "" {
 					vi = append(vi, i)
@@ -255,7 +255,7 @@ func translateIngresses(ingresses []v1.Ingress) *envoyConfiguration {
 
 				virtualHost.addlocalroute(clustername, RouteMatch(Pathtranslate(path, pathType)))
 				cluster.addclustername(clustername)
-				if i.Annotations["ingressendpoints"] != "" {
+				if i.Annotations["yggdrasil.uswitch.com/ingressendpoints"] != "" {
 					for _, ip := range strings.Split(i.Annotations["yggdrasil.uswitch.com/ingressendpoints"], ",") {
 						cluster.addUpstream(ip)
 					}

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -256,7 +256,7 @@ func translateIngresses(ingresses []v1.Ingress) *envoyConfiguration {
 				virtualHost.addlocalroute(clustername, RouteMatch(Pathtranslate(path, pathType)))
 				cluster.addclustername(clustername)
 				if i.Annotations["ingressendpoints"] != "" {
-					for _, ip := range strings.Split(i.Annotations["ingressendpoints"], ",") {
+					for _, ip := range strings.Split(i.Annotations["yggdrasil.uswitch.com/ingressendpoints"], ",") {
 						cluster.addUpstream(ip)
 					}
 				} else {

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -168,21 +168,18 @@ func validIngressFilter(ingresses []v1.Ingress) []v1.Ingress {
 
 Ingress:
 	for _, i := range ingresses {
-		for _, j := range i.Status.LoadBalancer.Ingress {
-			if j.Hostname != "" || j.IP != "" {
-				for _, k := range i.Spec.Rules {
-					if k.Host != "" {
-						vi = append(vi, i)
-						continue Ingress
-					}
+		if i.Status.LoadBalancer.Ingress != nil || i.Annotations["ingressendpoints"] != "" {
+			for _, k := range i.Spec.Rules {
+				if k.Host != "" {
+					vi = append(vi, i)
+					continue Ingress
 				}
-				logrus.Debugf("no host found in ingress config for: %+v in namespace: %+v", i.Name, i.Namespace)
-				continue Ingress
 			}
+			logrus.Debugf("no host found in ingress config for: %+v in namespace: %+v", i.Name, i.Namespace)
+			continue Ingress
 		}
 		logrus.Debugf("no hostname or ip for loadbalancer found in ingress config for: %+v in namespace: %+v", i.Name, i.Namespace)
 	}
-
 	return vi
 }
 
@@ -232,52 +229,59 @@ func translateIngresses(ingresses []v1.Ingress) *envoyConfiguration {
 	virtualhosts := map[string]*virtualHost{}
 
 	for _, i := range ingresses {
-		for _, j := range i.Status.LoadBalancer.Ingress {
-			for _, rule := range i.Spec.Rules {
 
-				_, ok := virtualhosts[rule.Host]
-				if !ok {
-					virtualhosts[rule.Host] = newVirtualHost(rule.Host)
+		for _, rule := range i.Spec.Rules {
+
+			_, ok := virtualhosts[rule.Host]
+			if !ok {
+				virtualhosts[rule.Host] = newVirtualHost(rule.Host)
+			}
+
+			virtualHost := virtualhosts[rule.Host]
+
+			for _, httppath := range httppaths(rule) {
+
+				_, exist := clusters[key{host: rule.Host, path: httppath.Path}]
+				if !exist {
+					clusters[key{host: rule.Host, path: httppath.Path}] = newCluster(rule.Host)
+				}
+				cluster := clusters[key{host: rule.Host, path: httppath.Path}]
+
+				path := stringOrDefault(httppath.Path, "/")
+				// Default to implementation specific path matching if not set.
+				pathType := derefPathTypeOr(httppath.PathType, v1.PathTypeImplementationSpecific)
+
+				clustername := fmt.Sprint(strings.Replace(rule.Host, ".", "_", -1), stringTohash(httppath.Path))
+
+				virtualHost.addlocalroute(clustername, RouteMatch(Pathtranslate(path, pathType)))
+				cluster.addclustername(clustername)
+				if i.Annotations["ingressendpoints"] != "" {
+					for _, ip := range strings.Split(i.Annotations["ingressendpoints"], ",") {
+						cluster.addUpstream(ip)
+					}
+				} else {
+					for _, j := range i.Status.LoadBalancer.Ingress {
+						if j.Hostname != "" {
+							cluster.addUpstream(j.Hostname)
+						} else if j.IP != "" {
+							cluster.addUpstream(j.IP)
+						}
+					}
 				}
 
-				virtualHost := virtualhosts[rule.Host]
-
-				for _, httppath := range httppaths(rule) {
-
-					_, exist := clusters[key{host: rule.Host, path: httppath.Path}]
-					if !exist {
-						clusters[key{host: rule.Host, path: httppath.Path}] = newCluster(rule.Host)
-					}
-					cluster := clusters[key{host: rule.Host, path: httppath.Path}]
-
-					path := stringOrDefault(httppath.Path, "/")
-					// Default to implementation specific path matching if not set.
-					pathType := derefPathTypeOr(httppath.PathType, v1.PathTypeImplementationSpecific)
-
-					clustername := fmt.Sprint(strings.Replace(rule.Host, ".", "_", -1), stringTohash(httppath.Path))
-
-					virtualHost.addlocalroute(clustername, RouteMatch(Pathtranslate(path, pathType)))
-					cluster.addclustername(clustername)
-
-					if j.Hostname != "" {
-						cluster.addUpstream(j.Hostname)
-					} else {
-						cluster.addUpstream(j.IP)
-					}
-
-					if i.GetAnnotations()["yggdrasil.uswitch.com/healthcheck-path"] != "" {
-						cluster.addHealthCheckPath(i.GetAnnotations()["yggdrasil.uswitch.com/healthcheck-path"])
-					}
+				if i.GetAnnotations()["yggdrasil.uswitch.com/healthcheck-path"] != "" {
+					cluster.addHealthCheckPath(i.GetAnnotations()["yggdrasil.uswitch.com/healthcheck-path"])
 				}
+			}
 
-				if i.GetAnnotations()["yggdrasil.uswitch.com/timeout"] != "" {
-					timeout, err := time.ParseDuration(i.GetAnnotations()["yggdrasil.uswitch.com/timeout"])
-					if err == nil {
-						virtualHost.addVhostTimeout(timeout)
-					}
+			if i.GetAnnotations()["yggdrasil.uswitch.com/timeout"] != "" {
+				timeout, err := time.ParseDuration(i.GetAnnotations()["yggdrasil.uswitch.com/timeout"])
+				if err == nil {
+					virtualHost.addVhostTimeout(timeout)
 				}
 			}
 		}
+
 	}
 
 	for _, cluster := range clusters {

--- a/pkg/envoy/route.go
+++ b/pkg/envoy/route.go
@@ -116,10 +116,10 @@ func Pathtranslate(path string, pathtype v1.PathType) *Route {
 }
 
 // RouteMatch creates a *envoy_route_v3.RouteMatch for the supplied *dag.Route.
-func RouteMatch(route *Route) *envoy_route_v3.RouteMatch {
+func RouteMatch(route *Route) envoy_route_v3.RouteMatch {
 	switch c := route.PathMatchCondition.(type) {
 	case *RegexMatchCondition:
-		return &envoy_route_v3.RouteMatch{
+		return envoy_route_v3.RouteMatch{
 			PathSpecifier: &envoy_route_v3.RouteMatch_SafeRegex{
 				// Add an anchor since we at the very least have a / as a string literal prefix.
 				// Reduces regex program size so Envoy doesn't reject long prefix matches.
@@ -129,7 +129,7 @@ func RouteMatch(route *Route) *envoy_route_v3.RouteMatch {
 	case *PrefixMatchCondition:
 		switch c.PrefixMatchType {
 		case PrefixMatchSegment:
-			return &envoy_route_v3.RouteMatch{
+			return envoy_route_v3.RouteMatch{
 				PathSpecifier: &envoy_route_v3.RouteMatch_PathSeparatedPrefix{
 					PathSeparatedPrefix: c.Prefix,
 				},
@@ -137,20 +137,20 @@ func RouteMatch(route *Route) *envoy_route_v3.RouteMatch {
 		case PrefixMatchString:
 			fallthrough
 		default:
-			return &envoy_route_v3.RouteMatch{
+			return envoy_route_v3.RouteMatch{
 				PathSpecifier: &envoy_route_v3.RouteMatch_Prefix{
 					Prefix: c.Prefix,
 				},
 			}
 		}
 	case *ExactMatchCondition:
-		return &envoy_route_v3.RouteMatch{
+		return envoy_route_v3.RouteMatch{
 			PathSpecifier: &envoy_route_v3.RouteMatch_Path{
 				Path: c.Path,
 			},
 		}
 	default:
-		return &envoy_route_v3.RouteMatch{}
+		return envoy_route_v3.RouteMatch{}
 	}
 }
 

--- a/pkg/k8s/aggregator.go
+++ b/pkg/k8s/aggregator.go
@@ -99,7 +99,7 @@ func (i *IngressAggregator) List() ([]v1.Ingress, error) {
 			if len(ingress.Status.LoadBalancer.Ingress) <= 0 {
 				if len(store.endpoints) > 0 {
 					//inject Ingressendpoints
-					ingress.Annotations["ingressendpoints"] = strings.Join(store.endpoints[:], ",")
+					ingress.Annotations["yggdrasil.uswitch.com/ingressendpoints"] = strings.Join(store.endpoints[:], ",")
 				} else {
 					logrus.Debugf("the ingress ip address is empty %s", store.endpoints)
 				}

--- a/pkg/k8s/aggregator.go
+++ b/pkg/k8s/aggregator.go
@@ -63,12 +63,12 @@ func (i *IngressAggregator) OnUpdate(old, new interface{}) {
 }
 
 //AddSource adds a new source for watching ingresses, must be called before running
-func (i *IngressAggregator) AddSource(source cache.ListerWatcher, endpoint []string) {
+func (i *IngressAggregator) AddSource(source cache.ListerWatcher, endpoints []string) {
 	//Todo implement handler for events
 	store, controller := cache.NewIndexerInformer(source, &v1.Ingress{}, time.Minute, i, cache.Indexers{})
 	cachestore := Store{
 		cachestore: store,
-		endpoints:  endpoint,
+		endpoints:  endpoints,
 	}
 	i.stores = append(i.stores, cachestore)
 	i.controllers = append(i.controllers, controller)

--- a/pkg/k8s/aggregator.go
+++ b/pkg/k8s/aggregator.go
@@ -21,10 +21,9 @@ type Ingresswatcher struct {
 
 //IngressAggregator used for running Ingress infomers
 type IngressAggregator struct {
-	stores           []Store
-	controllers      []cache.Controller
-	IngressEndpoints []string
-	events           chan interface{}
+	stores      []Store
+	controllers []cache.Controller
+	events      chan interface{}
 }
 type Store struct {
 	cachestore cache.Store

--- a/pkg/k8s/aggregator.go
+++ b/pkg/k8s/aggregator.go
@@ -3,11 +3,10 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -22,10 +21,14 @@ type Ingresswatcher struct {
 
 //IngressAggregator used for running Ingress infomers
 type IngressAggregator struct {
-	stores           []cache.Store
+	stores           []Store
 	controllers      []cache.Controller
 	IngressEndpoints []string
 	events           chan interface{}
+}
+type Store struct {
+	cachestore cache.Store
+	endpoints  []string
 }
 
 func (i *IngressAggregator) Events() chan interface{} {
@@ -60,10 +63,14 @@ func (i *IngressAggregator) OnUpdate(old, new interface{}) {
 }
 
 //AddSource adds a new source for watching ingresses, must be called before running
-func (i *IngressAggregator) AddSource(source cache.ListerWatcher) {
+func (i *IngressAggregator) AddSource(source cache.ListerWatcher, endpoint []string) {
 	//Todo implement handler for events
 	store, controller := cache.NewIndexerInformer(source, &v1.Ingress{}, time.Minute, i, cache.Indexers{})
-	i.stores = append(i.stores, store)
+	cachestore := Store{
+		cachestore: store,
+		endpoints:  endpoint,
+	}
+	i.stores = append(i.stores, cachestore)
 	i.controllers = append(i.controllers, controller)
 }
 
@@ -73,8 +80,7 @@ func NewIngressAggregator(sources []Ingresswatcher) *IngressAggregator {
 		events: make(chan interface{}),
 	}
 	for _, s := range sources {
-		a.AddSource(s.Watcher)
-		a.IngressEndpoints = append(a.IngressEndpoints, s.IngressEndpoints...)
+		a.AddSource(s.Watcher, s.IngressEndpoints)
 	}
 	return a
 }
@@ -83,7 +89,7 @@ func NewIngressAggregator(sources []Ingresswatcher) *IngressAggregator {
 func (i *IngressAggregator) List() ([]v1.Ingress, error) {
 	is := make([]v1.Ingress, 0)
 	for _, store := range i.stores {
-		ingresses := store.List()
+		ingresses := store.cachestore.List()
 		for _, obj := range ingresses {
 			ingress, ok := obj.(*v1.Ingress)
 			if !ok {
@@ -91,13 +97,11 @@ func (i *IngressAggregator) List() ([]v1.Ingress, error) {
 			}
 			// check if loadbalancer status exist in ingress
 			if len(ingress.Status.LoadBalancer.Ingress) <= 0 {
-				if len(i.IngressEndpoints) > 0 {
-					//get random ip from Ingressendpoints
-					ip := rand.Int() % len(i.IngressEndpoints)
-					logrus.Debugf("ip address would be %s", i.IngressEndpoints[ip])
-					ingress.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: i.IngressEndpoints[ip]}}
+				if len(store.endpoints) > 0 {
+					//inject Ingressendpoints
+					ingress.Annotations["ingressendpoints"] = strings.Join(store.endpoints[:], ",")
 				} else {
-					logrus.Debugf("the ingress ip address is empty %s", i.IngressEndpoints)
+					logrus.Debugf("the ingress ip address is empty %s", store.endpoints)
 				}
 			}
 			is = append(is, *ingress)

--- a/pkg/k8s/nodes.go
+++ b/pkg/k8s/nodes.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -31,8 +30,7 @@ func ClusterLoadbalancersIp(Nodeselector IngressNodeSelector, Endpoints IngressE
 				logrus.Debugf("can't get node information %s", err)
 			}
 			for i := 0; i < len(nodes.Items); i++ {
-				nodeip := []corev1.NodeAddress{}
-				nodeip = nodes.Items[i].Status.Addresses
+				nodeip := nodes.Items[i].Status.Addresses
 				ips = append(ips, nodeip[0].Address)
 			}
 		}


### PR DESCRIPTION
previously the code randomly chooce a single ip from pool of all clusters ips and set it equal to `Status.LoadBalancer.Ingress{ IP }` .
but in this PR I inject the endpoint as a annotation to ingress resource while tranlate and then will add it as cluster endpoint. 
