### PR TITLE
Fix logging error in server.go address listen

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -58,7 +58,9 @@ func runEnvoyServer(envoyServer server.Server, address string, healthAddress str
 
 	lis, err := net.Listen("tcp", address)
 	if err != nil {
-		log.Fatal("failed to listen %s", err)
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Fatal("failed to listen address")
 	}
 
 	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, envoyServer)


### PR DESCRIPTION
Tests were failing because logrus doesn't like formatting options in the error message strings - this format is recommended in their [documentation](https://github.com/sirupsen/logrus#fields).

After making this change, tests are OK again.